### PR TITLE
Add timeout for overlay integration test connection

### DIFF
--- a/electron-overlay/test/test-integration.js
+++ b/electron-overlay/test/test-integration.js
@@ -44,7 +44,13 @@ async function testOverlayConnection() {
     console.log('1. Testing WebSocket connection...');
     const ws = new WebSocket('ws://localhost:8765');
 
+    const openTimeout = setTimeout(() => {
+      console.error('❌ WebSocket connection timed out');
+      process.exit(1);
+    }, 5000);
+
     ws.on('open', () => {
+      clearTimeout(openTimeout);
       console.log('✅ WebSocket connected successfully');
       
       // Test sending data


### PR DESCRIPTION
## Summary
- ensure overlay integration test fails when connection cannot be opened within 5s

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ffef96a9c832b9a8c5c42d6c57e4c