### PR TITLE
Update webhook script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
    ```bash
    npm run webhook
    ```
+   This command runs `node server/server.js`.
 
 2. When the server starts, it will show you a public URL like:
    ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "webhook": "node server/webhook.js",
+    "webhook": "node server/server.js",
     "setup-overlay": "node setup-overlay.js",
     "test-overlay": "node test-overlay.js",
     "overlay:dev": "cd electron-overlay && npm run dev",


### PR DESCRIPTION
## Summary
- run `server/server.js` as webhook script
- clarify README instructions for the webhook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ffef42d44832b992bc39492135a12