### PR TITLE
Fix overlay port config

### DIFF
--- a/electron-overlay/src/main.js
+++ b/electron-overlay/src/main.js
@@ -113,7 +113,8 @@ function setupGlobalShortcuts() {
 
 // WebSocket server for communication with main Dialara app
 function createWebSocketServer() {
-  wsServer = new WebSocket.Server({ port: 8765 });
+  const port = parseInt(process.env.OVERLAY_PORT, 10) || 8765;
+  wsServer = new WebSocket.Server({ port });
   
   wsServer.on('connection', (ws) => {
     console.log('Dialara main app connected to overlay');
@@ -137,7 +138,7 @@ function createWebSocketServer() {
     });
   });
   
-  console.log('WebSocket server started on port 8765');
+  console.log(`WebSocket server started on port ${port}`);
 }
 
 // IPC handlers


### PR DESCRIPTION
## Summary
- respect `OVERLAY_PORT` in overlay's WebSocket server

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*
- `node electron-overlay/test/test-integration.js` *(fails: cannot find module `ws`)*

------
https://chatgpt.com/codex/tasks/task_e_686ffef19b40832b9458d38daacca46f